### PR TITLE
ci(docker): add Dockerfile build recipe

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.devcontainer
+.github
+.vscode
+.git
+.gitignore
+.gitattributes
+.mocharc.json
+.nvmrc
+*.md
+dist

--- a/.env.example
+++ b/.env.example
@@ -15,28 +15,7 @@ OPENAI_TTS_VOICE=
 # [Optional] Default: ""
 ASSISTANT_PROMPT_DEFAULT=
 # [Optional] Default: ""
-ASSISTANT_PROMPT_HABIT_TRACKER="角色设定：
-你是一名职业夸夸师，负责在微信群中对成员的打卡内容进行热情的鼓励和夸奖。
-任务描述：
-    你会收到一份结构化的数据，包括：
-        time：打卡时间
-        name：打卡人姓名
-        event：打卡事件类型（如力扣、健身等）
-        note：打卡人写的笔记
-    你的职责是根据每个人的打卡内容，创作一段鼓励和夸奖的话。
-要求：
-    使用夸张、热情的语言，风格多样化，不局限于示例中的风格。
-    回复长度控制在两到三句以内。
-    避免使用过于粗俗的语言，保持积极向上的语气。
-示例：
-示例一：
-时间：19:48
-事件：健身打卡
-“哇塞！这个时间还在挥洒汗水，你简直是健身界的夜行侠！你的毅力连星辰都为之闪耀，加油，未来的健身达人就是你！💪🌟”
-示例二：
-时间：21:30
-事件：力扣打卡
-“深夜还在挑战算法难题，你的聪明才智已经突破天际！未来的编程大神非你莫属，继续保持，这股冲劲无人能敌！🚀📘”"
+ASSISTANT_PROMPT_HABIT_TRACKER=
 
 #############
 # Wechaty Service
@@ -45,10 +24,10 @@ ASSISTANT_PROMPT_HABIT_TRACKER="角色设定：
 # [Optional] Default: jarvis
 # Names of the chatbot, separated by commas ','
 WECHATY_CHATBOT_NAME=
-# [Optional] Default: []
+# [Optional] Default: [""]
 # Names of groupchat, separated by commas ','
 WECHATY_GROUPCHAT_WHITELIST=
-# [Optional] Default: []
+# [Optional] Default: [""]
 # Names of contact, separated by commas ','
 WECHATY_CONTACT_WHITELIST=
 
@@ -64,6 +43,7 @@ LOG_LEVEL=
 # Persistent Storage
 #############
 
+# Deprecated !!!
 # [Optional] Default: project_root/prisma/default.db
 # Sqlite3 DB File Location
 DATABASE_URL=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+FROM node:20-slim AS base
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+# https://githubcom/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker
+# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# NOTE: This installs some missing dependencies for chromium in docker
+RUN apt-get update \
+    && apt-get install -y wget gnupg \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Stage 2: Install non-dev dependencies
+FROM base AS prod-deps
+ 
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml .
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm fetch --frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile --prod
+
+# Generate prisma client under node_modules 
+COPY prisma ./prisma
+RUN pnpm generate
+
+# Stage 3: Install all dependencies and build the app
+FROM base AS build
+ 
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml .
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm fetch --frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile
+# Copy all neccessary source codes
+COPY . .
+# Generate prisma client for building
+RUN pnpm generate
+RUN pnpm build
+
+# Stage 4: Copy the built result and the dependencies to the final image
+FROM base
+ 
+WORKDIR /app
+
+COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/tsconfig.json ./tsconfig.json
+COPY --from=build /app/assets ./assets
+COPY --from=build /app/prisma ./prisma
+
+ENV NODE_ENV=production
+# EXPOSE 8080/tcp
+
+CMD ["pnpm", "start:prod"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+services:
+    convo:
+        image: satayking/convo:latest
+        container_name: convo
+        env_file:
+            - .env
+        volumes:
+            - convo_data:/app/prisma
+
+volumes:
+    convo_data:
+

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "start": "npm run clean && npm run build && npm run serve",
+    "start:prod": "npm run migrate:prod && npm run serve",
     "build": "tsc --build --verbose --pretty",
     "build:debug": "tsc --build --verbose --pretty --sourceMap",
     "clean": "tsc --build --clean",
@@ -28,11 +29,11 @@
     "@types/qrcode": "^1.5.5",
     "chai": "^5.1.1",
     "mocha": "^10.7.3",
-    "prisma": "^5.19.1",
     "tsx": "^4.16.2",
     "typescript": "^5.5.3"
   },
   "dependencies": {
+    "prisma": "^5.19.1",
     "@prisma/client": "5.19.1",
     "dotenv": "^16.4.5",
     "file-box": "^1.4.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       openai:
         specifier: ^4.53.0
         version: 4.53.0
+      prisma:
+        specifier: ^5.19.1
+        version: 5.19.1
       qrcode:
         specifier: ^1.5.3
         version: 1.5.3
@@ -54,9 +57,6 @@ importers:
       mocha:
         specifier: ^10.7.3
         version: 10.7.3
-      prisma:
-        specifier: ^5.19.1
-        version: 5.19.1
       tsx:
         specifier: ^4.16.2
         version: 4.16.2

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -59,7 +59,7 @@ class DatabaseSetup {
       logger.warn(logEventTemplate(e));
     });
     this.prismaClient.$on("error", (e: Prisma.LogEvent) => {
-      logger.error(logEventTemplate(e));
+      logger.warn("[ERROR] " + logEventTemplate(e));
     });
   }
 }

--- a/src/libs/openai/clients.ts
+++ b/src/libs/openai/clients.ts
@@ -1,8 +1,9 @@
 import { config } from "@config";
 import OpenAIClient, { AssistantEnum } from "@libs/openai";
+import { assistantPrompts } from "@utils/constants";
 
 class OpenAIClients {
-  public static assistantPrompts: Record<AssistantEnum, string | null>;
+  public static assistantPrompts: Record<AssistantEnum, string>;
 
   public static openAIClients: Partial<Record<keyof typeof this.assistantPrompts, OpenAIClient>> = {};
 
@@ -10,9 +11,10 @@ class OpenAIClients {
    * Initialize openai clients with their corresponding instruction/prompt
    */
   public static async initialize(): Promise<void> {
+    // Overwrite prompts if provided by config 
     OpenAIClients.assistantPrompts = {
-      [AssistantEnum.DEFAULT]: config.ASSISTANT_PROMPT_DEFAULT,
-      [AssistantEnum.HABIT_TRACKER]: config.ASSISTANT_PROMPT_HABIT_TRACKER
+      [AssistantEnum.DEFAULT]: config.ASSISTANT_PROMPT_DEFAULT || assistantPrompts[AssistantEnum.DEFAULT],
+      [AssistantEnum.HABIT_TRACKER]: config.ASSISTANT_PROMPT_HABIT_TRACKER || assistantPrompts[AssistantEnum.HABIT_TRACKER],
     };
 
     for (const key of Object.keys(this.assistantPrompts) as Array<keyof typeof this.assistantPrompts>) {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,32 @@
+import { AssistantEnum } from "@libs/openai";
+
+// Prompts for OpenAI Assistants by default, can be overwritten by config
+const assistantPrompts: Record<AssistantEnum, string> = {
+    [AssistantEnum.DEFAULT]: "",
+    [AssistantEnum.HABIT_TRACKER]: `角色设定：
+你是一名职业夸夸师，负责在微信群中对成员的打卡内容进行热情的鼓励和夸奖。
+任务描述：
+    你会收到一份结构化的数据，包括：
+        time：打卡时间
+        name：打卡人姓名
+        event：打卡事件类型（如力扣、健身等）
+        note：打卡人写的笔记
+    你的职责是根据每个人的打卡内容，创作一段鼓励和夸奖的话。
+要求：
+    使用夸张、热情的语言，风格多样化，不局限于示例中的风格。
+    回复长度控制在两到三句以内。
+    避免使用过于粗俗的语言，保持积极向上的语气。
+示例：
+示例一：
+时间：19:48
+事件：健身打卡
+“哇塞！这个时间还在挥洒汗水，你简直是健身界的夜行侠！你的毅力连星辰都为之闪耀，加油，未来的健身达人就是你！💪🌟”
+示例二：
+时间：21:30
+事件：力扣打卡
+“深夜还在挑战算法难题，你的聪明才智已经突破天际！未来的编程大神非你莫属，继续保持，这股冲劲无人能敌！🚀📘”`,
+};
+
+export {
+    assistantPrompts
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -115,6 +115,6 @@
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
   "include": [
-    "src/**/*"
+    "./src/**/*"
   ]
 }


### PR DESCRIPTION
- Add recipe for building nodejs app with Prisma (Prisma is so annoying that you have to move it to non-dev dependency in order to create a smooth build steps for Docker)
- Move default prompts of assistants from .env to utils/constants.ts to keep env config files concise
- Add a docker-compose.yml with persistent storage using Docker volumes (sqlite3 default.db is stored here)